### PR TITLE
Common offline status for all tests

### DIFF
--- a/tests/testthat/helper-offline.R
+++ b/tests/testthat/helper-offline.R
@@ -1,11 +1,13 @@
 
-skip_if_offline <- function() {
-  ping_res <- tryCatch(pingr::ping_port("github.com", count = 1, timeout = 0.2),
-                       error = function(e) NA)
-  if (is.na(ping_res)) {
-    skip("Offline")
-  }
+offline <- function() {
+  ping_res <- tryCatch(
+    pingr::ping_port("github.com", count = 1, timeout = 0.2),
+    error = function(e) NA
+  )
+  is.na(ping_res)
 }
+OFFLINE <- offline()
+skip_if_offline <- function() if (OFFLINE) skip("Offline")
 
 skip_if_no_token <- function() {
   if (is.na(Sys.getenv("GH_TESING", NA_character_))) {


### PR DESCRIPTION
I started to use this skipping approach over in googledrive and we are giving it a thorough workout. We find that `skip_if_offline()` can happen sporadically for no genuine reason. I suspect it's better to determine online vs offline once, at setup, then use that state throughout.