### PR TITLE
Fix URL plucking with empty remotes

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -60,7 +60,9 @@ git_remotes <- function(path = ".") {
   conf <- git_config(path)
   remotes <- conf[grepl("^remote", names(conf))]
 
+  remotes <- discard(remotes, function(x) is.null(x$url))
   urls <- vapply(remotes, "[[", "url", FUN.VALUE = character(1))
+
   names(urls) <- gsub('^remote "(.*?)"$', "\\1", names(remotes))
   urls
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -49,3 +49,17 @@ modify_vector <- function(x, y = NULL) {
   lnames <- function(x) tolower(names(x))
   c(x[!(lnames(x) %in% lnames(y))], y)
 }
+
+
+discard <- function(.x, .p, ...) {
+  sel <- probe(.x, .p, ...)
+  .x[is.na(sel) | !sel]
+}
+probe <- function(.x, .p, ...) {
+  if (is.logical(.p)) {
+    stopifnot(length(.p) == length(.x))
+    .p
+  } else {
+    vapply(.x, .p, logical(1), ...)
+  }
+}


### PR DESCRIPTION
I'm getting failures in `usethis` because `git_remotes()` does not handle anonymous remotes with no URL fields. This kind of remotes are used by magit to store metadata. E.g. the second one in this example:

```r
#> $ remote "lionel-":List of 2
#>  ..$ url  : chr "https://github.com/lionel-/oldie.git"
#>  ..$ fetch: chr "+refs/heads/*:refs/remotes/lionel-/*"
#> $ remote          :List of 1
#>  ..$ pushDefault: chr "lionel-"
#> $ remote "r-lib"  :List of 2
#>  ..$ url  : chr "https://github.com/r-lib/oldie.git"
#>  ..$ fetch: chr "+refs/heads/*:refs/remotes/r-lib/*"
```

This patch remove objects with empty fields before plucking them. I didn't write an unit test because `git_remotes()` is not a pure function and depends on the git configuration.