### PR TITLE
Raw GitHub responses returned as raw vectors

### DIFF
--- a/R/gh_response.R
+++ b/R/gh_response.R
@@ -23,7 +23,7 @@ gh_process_response <- function(response) {
   attr(res, "method") <- response$request$method
   attr(res, "response") <- headers(response)
   attr(res, ".send_headers") <- response$request$headers
-  if(is_raw) {
+  if (is_raw) {
     class(res) <- c("gh_response", "raw")
   } else {
     class(res) <- c("gh_response", "list")

--- a/R/package.R
+++ b/R/package.R
@@ -60,7 +60,8 @@ NULL
 #'   preview feature of the API.
 #'
 #' @return Answer from the API as a \code{gh_response} object, which is also a
-#'   \code{list}. Failed requests will generate an R error.
+#'   \code{list}. Failed requests will generate an R error. Requests that
+#'   generate a raw response will return a raw vector.
 #'
 #' @importFrom httr content add_headers headers
 #'   status_code http_type GET POST PATCH PUT DELETE

--- a/R/print.R
+++ b/R/print.R
@@ -10,7 +10,7 @@
 #' @method print gh_response
 
 print.gh_response <- function(x, ...) {
-  if("raw" %in% class(x)) {
+  if (inherits(x, "raw")) {
     attr(x, c("method")) <- NULL
     attr(x, c("response")) <- NULL
     attr(x, ".send_headers") <- NULL

--- a/R/print.R
+++ b/R/print.R
@@ -4,11 +4,18 @@
 #' @param x The result object.
 #' @param ... Ignored.
 #' @return The JSON result.
-#' 
+#'
 #' @importFrom jsonlite prettify toJSON
 #' @export
 #' @method print gh_response
 
 print.gh_response <- function(x, ...) {
-  print(toJSON(unclass(x), pretty = TRUE, auto_unbox = TRUE))
+  if("raw" %in% class(x)) {
+    attr(x, c("method")) <- NULL
+    attr(x, c("response")) <- NULL
+    attr(x, ".send_headers") <- NULL
+    print.default(x)
+  } else {
+    print(toJSON(unclass(x), pretty = TRUE, auto_unbox = TRUE))
+  }
 }

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,3 +1,6 @@
+# devel
+
+-  Raw reponses from GitHub are returned as raw vector
 
 # 1.0.1
 

--- a/man/gh.Rd
+++ b/man/gh.Rd
@@ -56,7 +56,8 @@ preview feature of the API.}
 }
 \value{
 Answer from the API as a \code{gh_response} object, which is also a
-\code{list}. Failed requests will generate an R error.
+\code{list}. Failed requests will generate an R error. Requests that
+generate a raw response will return a raw vector.
 }
 \description{
 Minimal wrapper to access GitHub's API.

--- a/tests/testthat/test-mock-repos.R
+++ b/tests/testthat/test-mock-repos.R
@@ -115,7 +115,8 @@ test_that("repo raw files", {
     owner = "r-lib",
     repo = "gh",
     path = "DESCRIPTION",
-    .send_headers = c(Accept = "application/vnd.github.v3.raw")
+    .send_headers = c(Accept = "application/vnd.github.v3.raw"),
+    .token = tt()
   )
 
   expect_equal(attr(res, "response")[["x-github-media-type"]], "github.v3; param=raw")

--- a/tests/testthat/test-mock-repos.R
+++ b/tests/testthat/test-mock-repos.R
@@ -6,7 +6,7 @@ test_that("repos, some basics", {
   skip_if_offline()
   skip_on_cran()
   skip("needs mocking")
-  
+
   res <- gh("/user/repos", .token = tt())
   expect_true(all(c("id", "name", "full_name") %in% names(res[[1]])))
 
@@ -103,4 +103,21 @@ test_that("repos, some basics", {
     .token = tt()
   )
   expect_equal(res[[1]], "")            # TODO: better return value here?
+})
+
+test_that("repo raw files", {
+  skip_if_offline()
+  skip_on_cran()
+  skip("needs mocking")
+
+  res <- gh(
+    "GET /repos/:owner/:repo/contents/:path",
+    owner = "r-lib",
+    repo = "gh",
+    path = "DESCRIPTION",
+    .send_headers = c(Accept = "application/vnd.github.v3.raw")
+  )
+
+  expect_equal(attr(res, "response")[["x-github-media-type"]], "github.v3; param=raw")
+  expect_equal(class(res), c("gh_response", "raw"))
 })


### PR DESCRIPTION
-  Check GH media type to determine response type
-  Set raw response class as c("gh_response", "raw")
-  Modify print method to be raw-friendly
-  Document the fact that response type changes
-  Add test, NEWS

This makes the function not strictly type-safe but I think returning a raw vector makes sense for a raw response.

Also, new tests are skipped, as the other repo tests are because they are not mocked, but they pass when run.