### PR TITLE
Print the URL that cannot be found for 404

### DIFF
--- a/R/gh_response.R
+++ b/R/gh_response.R
@@ -40,6 +40,10 @@ gh_error <- function(response, call = sys.call(-1)) {
     msg <- append(msg, paste0("Read more at ", doc_url))
   }
 
+  if (status == 404) {
+    msg <- append(msg, c("", paste0("URL not found: ", response$request$url)))
+  }
+
   errors <- res$errors
   if (!is.null(errors)) {
     errors <- as.data.frame(do.call(rbind, errors))


### PR DESCRIPTION
Fixes #60 even more. Specifically https://github.com/r-lib/gh/issues/60#issuecomment-354770688

---

``` r
gh::gh("GET /repos/gapminder/gapminder")
#> Error in gh_process_response(raw): 
#> GitHub API error (404): 404 Not Found
#> Message: Not Found
#> Read more at https://developer.github.com/v3
#> 
#> URL not found: https://api.github.com/repos/gapminder/gapminder
```

Created on 2018-02-14 by the [reprex package](http://reprex.tidyverse.org) (v0.2.0).