### PR TITLE
Interruptible pagination loop

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -132,18 +132,28 @@ gh <- function(endpoint, ..., .token = NULL, .destfile = NULL,
 }
 
 gh_fill <- function(res, .limit) {
-  while (!is.null(.limit) && length(res) < .limit && gh_has_next(res)) {
-    res2 <- gh_next(res)
-    res3 <- c(res, res2)
-    attributes(res3) <- attributes(res2)
-    res <- res3
-  }
+  tryCatch(
+    {
+      while (!is.null(.limit) && length(res) < .limit && gh_has_next(res)) {
+        res2 <- gh_next(res)
+        res3 <- c(res, res2)
+        attributes(res3) <- attributes(res2)
+        res <- res3
+      }
 
-  if (! is.null(.limit) && length(res) > .limit) {
-    res_attr <- attributes(res)
-    res <- res[seq_len(.limit)]
-    attributes(res) <- res_attr
-  }
+      if (! is.null(.limit) && length(res) > .limit) {
+        res2 <- res[seq_len(.limit)]
+        attributes(res2) <- attributes(res)
+        res <- res2
+      }
+    },
+    error = function(e) {
+      warning("Error occurred, results may be incomplete: ", e$message, call. = FALSE)
+    },
+    interrupt = function(e) {
+      warning("Interrupted, results may be incomplete.", call. = FALSE)
+    }
+  )
 
   res
 }

--- a/R/package.R
+++ b/R/package.R
@@ -128,6 +128,10 @@ gh <- function(endpoint, ..., .token = NULL, .destfile = NULL,
 
   res <- gh_process_response(raw)
 
+  gh_fill(res, .limit)
+}
+
+gh_fill <- function(res, .limit) {
   while (!is.null(.limit) && length(res) < .limit && gh_has_next(res)) {
     res2 <- gh_next(res)
     res3 <- c(res, res2)


### PR DESCRIPTION
to return partial results, with a warning, if an interrupt or error occurs.

We seem to get an error from _curl_ instead of an `interrupt` exception. Is there a way to ask _curl_ to not care about interrupts?

I'd like to see a progress bar, too, but this requires parsing the `page=` part of the URL.

How about implementing `[.gh_response()` and `c.gh_response()` ?