### PR TITLE
Point to .limit argument from gh_next()

### DIFF
--- a/R/pagination.R
+++ b/R/pagination.R
@@ -65,6 +65,9 @@ gh_link <- function(gh_response, link) {
 #' @param gh_response An object returned by a \code{gh()} call.
 #' @return Answer from the API.
 #'
+#' @seealso The `.limit` argument to [gh()] supports fetching more than
+#'   one page.
+#'
 #' @name gh_next
 #' @export
 #' @examples

--- a/man/gh_next.Rd
+++ b/man/gh_next.Rd
@@ -43,3 +43,7 @@ x2 <- gh_next(x)
 sapply(x2, "[[", "login")
 }
 }
+\seealso{
+The \code{.limit} argument to \code{\link[=gh]{gh()}} supports fetching more than
+one page.
+}


### PR DESCRIPTION
Users looking into `gh_next()` probably want the `.limit` argument. Do we want to advertise even more prominently?