### PR TITLE
Increase per_page if .limit is given

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -36,6 +36,8 @@ NULL
 #' @param ... Name-value pairs giving API parameters. Will be matched
 #'   into \code{url} placeholders, sent as query parameters in \code{GET}
 #'   requests, and in the JSON body of \code{POST} requests.
+#' @param per_page Number of items to return per page. The default varies
+#'   across API endpoints and depending on the `.limit` argument.
 #' @param .destfile path to write response to disk.  If NULL (default), response will
 #'   be processed and returned as an object.  If path is given, response will
 #'   be written to disk in the form sent.
@@ -113,12 +115,24 @@ NULL
 #' }
 #'
 
-gh <- function(endpoint, ..., .token = NULL, .destfile = NULL,
+gh <- function(endpoint, ..., per_page = NULL, .token = NULL, .destfile = NULL,
                .overwrite = FALSE, .api_url = NULL, .method = "GET",
                .limit = NULL, .send_headers = NULL
                ) {
 
-  req <- gh_build_request(endpoint = endpoint, params = list(...),
+  params <- list(...)
+
+  if (is.null(per_page)) {
+    if (!is.null(.limit)) {
+      per_page <- max(min(.limit, 100), 1)
+    }
+  }
+
+  if (!is.null(per_page)) {
+    params <- c(params, list(per_page = per_page))
+  }
+
+  req <- gh_build_request(endpoint = endpoint, params = params,
                           token = .token, destfile = .destfile,
                           overwrite = .overwrite,
                           send_headers = .send_headers,

--- a/R/package.R
+++ b/R/package.R
@@ -36,8 +36,9 @@ NULL
 #' @param ... Name-value pairs giving API parameters. Will be matched
 #'   into \code{url} placeholders, sent as query parameters in \code{GET}
 #'   requests, and in the JSON body of \code{POST} requests.
-#' @param per_page Number of items to return per page. The default varies
-#'   across API endpoints and depending on the `.limit` argument.
+#' @param per_page Number of items to return per page. If omitted,
+#'   will be substituted by `max(.limit, 100)` if `.limit` is set,
+#'   otherwise determined by the API (never greater than 100).
 #' @param .destfile path to write response to disk.  If NULL (default), response will
 #'   be processed and returned as an object.  If path is given, response will
 #'   be written to disk in the form sent.

--- a/man/gh.Rd
+++ b/man/gh.Rd
@@ -4,11 +4,11 @@
 \name{gh}
 \alias{gh}
 \alias{gh-package}
-\alias{gh}
 \title{GitHub API}
 \usage{
-gh(endpoint, ..., .token = NULL, .destfile = NULL, .overwrite = FALSE,
-  .api_url = NULL, .method = "GET", .limit = NULL, .send_headers = NULL)
+gh(endpoint, ..., per_page = NULL, .token = NULL, .destfile = NULL,
+  .overwrite = FALSE, .api_url = NULL, .method = "GET",
+  .limit = NULL, .send_headers = NULL)
 }
 \arguments{
 \item{endpoint}{GitHub API endpoint. Must be one of the following forms:
@@ -26,6 +26,9 @@ to \code{GET}.}
 \item{...}{Name-value pairs giving API parameters. Will be matched
 into \code{url} placeholders, sent as query parameters in \code{GET}
 requests, and in the JSON body of \code{POST} requests.}
+
+\item{per_page}{Number of items to return per page. The default varies
+across API endpoints and depending on the \code{.limit} argument.}
 
 \item{.token}{Authentication token.}
 

--- a/man/gh.Rd
+++ b/man/gh.Rd
@@ -27,8 +27,9 @@ to \code{GET}.}
 into \code{url} placeholders, sent as query parameters in \code{GET}
 requests, and in the JSON body of \code{POST} requests.}
 
-\item{per_page}{Number of items to return per page. The default varies
-across API endpoints and depending on the \code{.limit} argument.}
+\item{per_page}{Number of items to return per page. If omitted,
+will be substituted by \code{max(.limit, 100)} if \code{.limit} is set,
+otherwise determined by the API (never greater than 100).}
 
 \item{.token}{Authentication token.}
 


### PR DESCRIPTION
so that fewer requests are needed. Need to expose argument to avoid collisions with `per_page` given in `...` .