### PR TITLE
Emphasise copy and paste from API

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -48,26 +48,20 @@ you can copy and paste `GET /users/:username/repos` into your `gh()`
 call. E.g.
 
 ```{r}
-my_repos <- gh("GET /users/gaborcsardi/repos")
-vapply(my_repos, "[[", "", "name")
-```
-
-
-Parameters can be passed as extra arguments. E.g.
-
-```{r}
-my_repos <- gh("/user/repos", type = "public")
+my_repos <- gh("GET /users/:username/repos", username = "gaborcsardi")
 vapply(my_repos, "[[", "", "name")
 ```
 
 The JSON result sent by the API is converted to an R object.
 
-If the end point itself has parameters, these can also be passed
-as extra arguments:
+Parameters can be passed as extra arguments. E.g.
 
 ```{r}
-j_repos <- gh("/users/:username/repos", username = "jeroen")
-vapply(j_repos, "[[", "", "name")
+my_public_repos <- gh(
+  "/users/:username/repos",
+  username = "gaborcsardi",
+  type = "public")
+vapply(my_public_repos, "[[", "", "name")
 ```
 
 ### POST, PATCH, PUT and DELETE requests

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,7 +42,10 @@ The first argument of `gh()` is the endpoint. You can just copy and paste the
 API endpoints from the documentation. Note that the leading slash
 must be included as well. 
 
-From [https://developer.github.com/v3/repos/#list-user-repositories](https://developer.github.com/v3/repos/#list-user-repositories) you can copy and paste `GET /users/:username/repos` into your `gh()` call. E.g.
+From
+[https://developer.github.com/v3/repos/#list-user-repositories](https://developer.github.com/v3/repos/#list-user-repositories)
+you can copy and paste `GET /users/:username/repos` into your `gh()`
+call. E.g.
 
 ```{r}
 my_repos <- gh("GET /users/gaborcsardi/repos")
@@ -101,9 +104,10 @@ vapply(my_repos2, "[[", "", "name")
 
 ## Environment Variables
 
-+ The `GITHUB_API_URL` environment variable is used for the default github api url. 
-+ One of `GITHUB_PAT` or `GITHUB_TOKEN` environment variables is used, in this
-order, as default token.
+* The `GITHUB_API_URL` environment variable is used for the default github
+  api url.
+* One of `GITHUB_PAT` or `GITHUB_TOKEN` environment variables is used, in
+  this order, as default token.
 
 
 ## License

--- a/README.Rmd
+++ b/README.Rmd
@@ -99,6 +99,13 @@ my_repos2 <- gh("GET /users/:username/repos", username = "gaborcsardi",
 vapply(my_repos2, "[[", "", "name")
 ```
 
+## Environment Variables
+
++ The `GITHUB_API_URL` environment variable is used for the default github api url. 
++ One of `GITHUB_PAT` or `GITHUB_TOKEN` environment variables is used, in this
+order, as default token.
+
+
 ## License
 
 MIT © Gábor Csárdi, Jennifer Bryan, Hadley Wickham

--- a/README.Rmd
+++ b/README.Rmd
@@ -38,8 +38,19 @@ library(gh)
 Use the `gh()` function to access all API endpoints. The endpoints are
 listed in the [documentation](https://developer.github.com/v3/).
 
-The first argument of `gh()` is the endpoint. Note that the leading slash
-must be included as well. Parameters can be passed as extra arguments. E.g.
+The first argument of `gh()` is the endpoint. You can just copy and paste the 
+API endpoints from the documentation. Note that the leading slash
+must be included as well. 
+
+From [https://developer.github.com/v3/repos/#list-user-repositories](https://developer.github.com/v3/repos/#list-user-repositories) you can copy and paste `GET /users/:username/repos` into your `gh()` call. E.g.
+
+```{r}
+my_repos <- gh("GET /users/gaborcsardi/repos")
+vapply(my_repos, "[[", "", "name")
+```
+
+
+Parameters can be passed as extra arguments. E.g.
 
 ```{r}
 my_repos <- gh("/user/repos", type = "public")

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ call. E.g.
 
 
 ```r
-my_repos <- gh("GET /users/gaborcsardi/repos")
+my_repos <- gh("GET /users/:username/repos", username = "gaborcsardi")
 vapply(my_repos, "[[", "", "name")
 ```
 
@@ -61,48 +61,30 @@ vapply(my_repos, "[[", "", "name")
 #> [28] "hierformR"           "httpq"               "httr"
 ```
 
+The JSON result sent by the API is converted to an R object.
 
 Parameters can be passed as extra arguments. E.g.
 
 
 ```r
-my_repos <- gh("/user/repos", type = "public")
-vapply(my_repos, "[[", "", "name")
+my_public_repos <- gh(
+  "/users/:username/repos",
+  username = "gaborcsardi",
+  type = "public")
+vapply(my_public_repos, "[[", "", "name")
 ```
 
 ```
-#>  [1] "after"               "argufy"              "ask"                
-#>  [4] "baseimports"         "citest"              "clisymbols"         
-#>  [7] "cmaker"              "cmark"               "conditions"         
-#> [10] "crayon"              "debugme"             "devtools"           
-#> [13] "diffobj"             "disposables"         "dotenv"             
-#> [16] "elasticsearch-jetty" "falsy"               "fswatch"            
-#> [19] "gitty"               "httr"                "httrmock"           
-#> [22] "ISA"                 "keypress"            "lintr"              
-#> [25] "macBriain"           "maxygen"             "MISO"               
-#> [28] "parr"                "parsedate"           "pingr"
-```
-
-The JSON result sent by the API is converted to an R object.
-
-If the end point itself has parameters, these can also be passed
-as extra arguments:
-
-
-```r
-j_repos <- gh("/users/:username/repos", username = "jeroen")
-vapply(j_repos, "[[", "", "name")
-```
-
-```
-#>  [1] "2018.erum.io"    "acme"            "agent"           "algebre1"       
-#>  [5] "animation"       "antiword"        "apcf"            "arrow-r-dev"    
-#>  [9] "asantest"        "askpass"         "async"           "attobot"        
-#> [13] "autobrew"        "autobrew-old"    "awk"             "base64"         
-#> [17] "bcrypt"          "betty"           "bigartm"         "bigstatsr"      
-#> [21] "BiocBBSpack"     "blastula"        "blma"            "bookdown_travis"
-#> [25] "bottles"         "brew"            "brotli"          "cheerio"        
-#> [29] "cld3"            "collage"
+#>  [1] "after"               "alexr"               "altlist"            
+#>  [4] "argufy"              "ask"                 "base"               
+#>  [7] "baseimports"         "citest"              "cmaker"             
+#> [10] "covr"                "cranky"              "cranlike-server"    
+#> [13] "curl"                "dbplyr"              "devtools"           
+#> [16] "disposables"         "dot-emacs"           "dotenv"             
+#> [19] "dynex"               "elasticsearch-jetty" "ethel"              
+#> [22] "falsy"               "flowery"             "form-data"          
+#> [25] "franc"               "fswatch"             "gitty"              
+#> [28] "hierformR"           "httpq"               "httr"
 ```
 
 ### POST, PATCH, PUT and DELETE requests
@@ -141,12 +123,14 @@ vapply(my_repos2, "[[", "", "name")
 ```
 
 ```
-#>  [1] "installlite"    "ISA"            "isc"            "keynote"        "keypress"      
-#>  [6] "load-asciicast" "lpSolve"        "macBriain"      "magick"         "maxygen"       
-#> [11] "MISO"           "msgtools"       "multidplyr"     "node-jenkins"   "node-papi"     
-#> [16] "notifier"       "nsfw"           "oldie"          "pak-talk"       "parr"          
-#> [21] "parsedate"      "pkgbuild"       "playground"     "progress0"      "promises"      
-#> [26] "prompt"         "R-debugging"    "R-dev-web"      "r-font"         "r-source"
+#>  [1] "installlite"    "ISA"            "isc"            "keynote"       
+#>  [5] "keypress"       "load-asciicast" "lpSolve"        "macBriain"     
+#>  [9] "magick"         "maxygen"        "MISO"           "msgtools"      
+#> [13] "multidplyr"     "node-jenkins"   "node-papi"      "notifier"      
+#> [17] "nsfw"           "oldie"          "pak-talk"       "parr"          
+#> [21] "parsedate"      "pkgbuild"       "playground"     "progress0"     
+#> [25] "promises"       "prompt"         "R-debugging"    "R-dev-web"     
+#> [29] "r-font"         "r-source"
 ```
 
 ## Environment Variables

--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ vapply(my_repos2, "[[", "", "name")
 #> [26] "prompt"         "R-debugging"    "R-dev-web"      "r-font"         "r-source"
 ```
 
+## Environment Variables
+
++ The `GITHUB_API_URL` environment variable is used for the default github api url. 
++ One of `GITHUB_PAT` or `GITHUB_TOKEN` environment variables is used, in this
+order, as default token.
+
+
 ## License
 
 MIT © Gábor Csárdi, Jennifer Bryan, Hadley Wickham

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Minimalistic client to access
 
 ## Installation
 
-
 Install the package from CRAN as usual:
+
 
 ```r
 install.packages("gh")
@@ -33,8 +33,33 @@ library(gh)
 Use the `gh()` function to access all API endpoints. The endpoints are
 listed in the [documentation](https://developer.github.com/v3/).
 
-The first argument of `gh()` is the endpoint. Note that the leading slash
-must be included as well. Parameters can be passed as extra arguments. E.g.
+The first argument of `gh()` is the endpoint. You can just copy and paste the 
+API endpoints from the documentation. Note that the leading slash
+must be included as well. 
+
+From [https://developer.github.com/v3/repos/#list-user-repositories](https://developer.github.com/v3/repos/#list-user-repositories) you can copy and paste `GET /users/:username/repos` into your `gh()` call. E.g.
+
+
+```r
+my_repos <- gh("GET /users/gaborcsardi/repos")
+vapply(my_repos, "[[", "", "name")
+```
+
+```
+#>  [1] "after"               "alexr"               "altlist"            
+#>  [4] "argufy"              "ask"                 "base"               
+#>  [7] "baseimports"         "citest"              "cmaker"             
+#> [10] "covr"                "cranky"              "cranlike-server"    
+#> [13] "curl"                "dbplyr"              "devtools"           
+#> [16] "disposables"         "dot-emacs"           "dotenv"             
+#> [19] "dynex"               "elasticsearch-jetty" "ethel"              
+#> [22] "falsy"               "flowery"             "form-data"          
+#> [25] "franc"               "fswatch"             "gitty"              
+#> [28] "hierformR"           "httpq"               "httr"
+```
+
+
+Parameters can be passed as extra arguments. E.g.
 
 
 ```r
@@ -67,16 +92,14 @@ vapply(j_repos, "[[", "", "name")
 ```
 
 ```
-#>  [1] "apps"               "asantest"           "awk"               
-#>  [4] "base64"             "bcrypt"             "blog"              
-#>  [7] "brotli"             "cheerio"            "cmark"             
-#> [10] "commonmark"         "covr"               "cranlogs"          
-#> [13] "curl"               "cyphr"              "daff"              
-#> [16] "data"               "data.table.extras"  "devtools"          
-#> [19] "DiagrammeR"         "docdbi"             "docplyr"           
-#> [22] "docs-travis-ci-com" "dplyr"              "encode"            
-#> [25] "evaluate"           "feather"            "fib"               
-#> [28] "figures"            "gdtools"            "geojson"
+#>  [1] "2018.erum.io"    "acme"            "agent"           "algebre1"       
+#>  [5] "animation"       "antiword"        "apcf"            "arrow-r-dev"    
+#>  [9] "asantest"        "askpass"         "async"           "attobot"        
+#> [13] "autobrew"        "autobrew-old"    "awk"             "base64"         
+#> [17] "bcrypt"          "betty"           "bigartm"         "bigstatsr"      
+#> [21] "BiocBBSpack"     "blastula"        "blma"            "bookdown_travis"
+#> [25] "bottles"         "brew"            "brotli"          "cheerio"        
+#> [29] "cld3"            "collage"
 ```
 
 ### POST, PATCH, PUT and DELETE requests
@@ -115,26 +138,13 @@ vapply(my_repos2, "[[", "", "name")
 ```
 
 ```
-#>  [1] "pkgconfig"               "playground"             
-#>  [3] "praise"                  "prettycode"             
-#>  [5] "prettyunits"             "progress"               
-#>  [7] "prompt"                  "r-font"                 
-#>  [9] "R6"                      "rcorpora"               
-#> [11] "readline"                "remoji"                 
-#> [13] "resume"                  "rhub-presentations"     
-#> [15] "rintrojs"                "roxygen"                
-#> [17] "scidb"                   "spark"                  
-#> [19] "sparklyr"                "splicing"               
-#> [21] "tamper"                  "testthat"               
-#> [23] "trump"                   "user2016-tutorial-shiny"
-#> [25] "webdriver"               "whoami"
+#>  [1] "installlite"    "ISA"            "isc"            "keynote"        "keypress"      
+#>  [6] "load-asciicast" "lpSolve"        "macBriain"      "magick"         "maxygen"       
+#> [11] "MISO"           "msgtools"       "multidplyr"     "node-jenkins"   "node-papi"     
+#> [16] "notifier"       "nsfw"           "oldie"          "pak-talk"       "parr"          
+#> [21] "parsedate"      "pkgbuild"       "playground"     "progress0"      "promises"      
+#> [26] "prompt"         "R-debugging"    "R-dev-web"      "r-font"         "r-source"
 ```
-
-## Environment Variables
-
-+ The `GITHUB_API_URL` environment variable is used for the default github api url. 
-+ One of `GITHUB_PAT` or `GITHUB_TOKEN` environment variables is used, in this
-order, as default token.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ The first argument of `gh()` is the endpoint. You can just copy and paste the
 API endpoints from the documentation. Note that the leading slash
 must be included as well. 
 
-From [https://developer.github.com/v3/repos/#list-user-repositories](https://developer.github.com/v3/repos/#list-user-repositories) you can copy and paste `GET /users/:username/repos` into your `gh()` call. E.g.
+From
+[https://developer.github.com/v3/repos/#list-user-repositories](https://developer.github.com/v3/repos/#list-user-repositories)
+you can copy and paste `GET /users/:username/repos` into your `gh()`
+call. E.g.
 
 
 ```r
@@ -148,9 +151,10 @@ vapply(my_repos2, "[[", "", "name")
 
 ## Environment Variables
 
-+ The `GITHUB_API_URL` environment variable is used for the default github api url. 
-+ One of `GITHUB_PAT` or `GITHUB_TOKEN` environment variables is used, in this
-order, as default token.
+* The `GITHUB_API_URL` environment variable is used for the default github
+  api url.
+* One of `GITHUB_PAT` or `GITHUB_TOKEN` environment variables is used, in
+  this order, as default token.
 
 
 ## License


### PR DESCRIPTION
Fixes #90 

- Add instruction and example that shows that you can just copy and paste the API endpoints from the documentation.
- Add to [README.Rmd](https://github.com/r-lib/gh/blob/master/README.Rmd) the [`Environment Variables`](https://github.com/r-lib/gh#environment-variables) section. It was only on [README.md](https://github.com/r-lib/gh/blob/master/README.md) file.