### PR TITLE
Fix error when .progress = FALSE in gh()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 
 # development version
 
+* Fixed an error that occurred when calling `gh()` with `.progress = FALSE` 
+  (@gadenbuie, #115).
+
 # 1.1.0
 
 * Raw reponses from GitHub are now returned as raw vector.

--- a/R/package.R
+++ b/R/package.R
@@ -190,7 +190,7 @@ gh <- function(endpoint, ..., per_page = NULL, .token = NULL, .destfile = NULL,
   res <- gh_process_response(raw)
 
   while (!is.null(.limit) && length(res) < .limit && gh_has_next(res)) {
-    update_progress_bar(prbr, res)
+    if (.progress) update_progress_bar(prbr, res)
     res2 <- gh_next(res)
     res3 <- c(res, res2)
     attributes(res3) <- attributes(res2)


### PR DESCRIPTION
This is a very simple fix for #114 to avoid calling `update_progress_bar()` when `.progress = FALSE`.