### PR TITLE
If error with zero-length reponse, set error message to "Empty Body" …

### DIFF
--- a/R/gh_response.R
+++ b/R/gh_response.R
@@ -42,6 +42,7 @@ gh_process_response <- function(response) {
 gh_error <- function(response, call = sys.call(-1)) {
   heads <- headers(response)
   res <- content(response)
+  if (length(res) == 0) res <- list(message = "Empty Body")
   status <- status_code(response)
 
   msg <- c(


### PR DESCRIPTION
…so that correct error is thrown. This is common with [conditional requests](https://developer.github.com/v3/#conditional-requests) where a 304 error is returned with an empty body to indicate that the resource hasn't been modified.

Currently, `gh` fails to return the correct error from `gh_error()` when `res` is `raw(0)` (an empty response body).

``` r
library(gh)

issue <- "/repos/r-lib/gh/issues/1"
e_first <- gh(issue)
last_modified <- attributes(e_first)$response$`last-modified`

# Conditional request: https://developer.github.com/v3/#conditional-requests
gh(issue, .send_headers = c("If-Modified-Since" = last_modified))
#> Error: $ operator is invalid for atomic vectors
```

This PR checks if `length(res) == 0` and if so initializes `res = list(message = "Empty Body")`.

``` r
# With the change from this PR...
gh(issue, .send_headers = c("If-Modified-Since" = last_modified))
#> Error in gh_process_response(raw): 
#> GitHub API error (304): 304 Not Modified
#> Message: Empty Body
```

I tried to create a test based on the above reprex, but couldn't quickly figure out how to setup httrmock. Hopefully the above reprex is a good start.