### PR TITLE
Assign in parent

### DIFF
--- a/R/gh_token.R
+++ b/R/gh_token.R
@@ -102,7 +102,7 @@ should_use_keyring <- function() {
   err <- FALSE
   tryCatch(
     locked <- keyring::keyring_is_locked(),
-    error = function(e) err <- TRUE
+    error = function(e) err <<- TRUE
   )
   if (err) return(TRUE)
 
@@ -117,7 +117,7 @@ should_use_keyring <- function() {
   # It is better to fail here, once and for all.
   if (locked) {
     err <- FALSE
-    tryCatch(keyring::keyring_unlock(), error = function(e) err <- TRUE)
+    tryCatch(keyring::keyring_unlock(), error = function(e) err <<- TRUE)
     if (err) {
       cli_alert_info("{.pkg gh}: failed to unlock default keyring")
       return(FALSE)


### PR DESCRIPTION
This is a small change I made in #123 which should happen no matter what.

``` r
(val1 <- "a")
#> [1] "a"
(val2 <- 1)
#> [1] 1
tryCatch(
  {
    val1 <- "b"
    stop("oh no")
  }, error = function(e) {
    val2 <- 2  
  }
)
val1
#> [1] "b"
val2
#> [1] 1

(val1 <- "a")
#> [1] "a"
(val2 <- 1)
#> [1] 1
tryCatch(
  {
    val1 <- "b"
    stop("oh no")
  }, error = function(e) {
    val2 <<- 2  
  }
)
val1
#> [1] "b"
val2
#> [1] 2
```

<sup>Created on 2020-08-06 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>