### PR TITLE
Fix pagination for various response types

### DIFF
--- a/R/gh.R
+++ b/R/gh.R
@@ -208,7 +208,9 @@ gh <- function(endpoint, ..., per_page = NULL, .token = NULL, .destfile = NULL,
     res <- res3
   }
 
-  if (! is.null(.limit) && len > .limit) {
+  # We only subset for a non-named response.
+  if (! is.null(.limit) && len > .limit &&
+      ! "total_count" %in% names(res) && length(res) == len) {
     res_attr <- attributes(res)
     res <- res[seq_len(.limit)]
     attributes(res) <- res_attr

--- a/R/gh.R
+++ b/R/gh.R
@@ -223,7 +223,6 @@ gh_response_length <- function(res) {
     )
     tgt <- which(lst[nm])[1]
     if (is.na(tgt)) length(res) else length(res[[ nm[tgt] ]])
-    length(res[[2]])
   } else {
     length(res)
   }

--- a/R/gh.R
+++ b/R/gh.R
@@ -184,12 +184,18 @@ gh <- function(endpoint, ..., per_page = NULL, .token = NULL, .destfile = NULL,
 
     if (!is.null(names(res2)) && identical(names(res), names(res2))) {
       res3 <- mapply(           # Handle named array case
-        function(x, y) {        # e.g. GET /search/repositories
+        function(x, y, n) {        # e.g. GET /search/repositories
           z <- c(x, y)
-          if (is.atomic(z)) unique(z)
-          else z
+          atm <- is.atomic(z)
+          if (atm && n %in% c("total_count", "incomplete_results")) {
+            y
+          } else if (atm) {
+            unique(z)
+          } else {
+            z
+          }
         },
-        res, res2,
+        res, res2, names(res),
         SIMPLIFY = FALSE
       )
     } else {                    # Handle unnamed array case


### PR DESCRIPTION
Use 'total_count' and info from the schema on
how to calculate the "length" of a response.

Fixes #135.