### PR TITLE
update PAT validation for new token formats

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,4 +38,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: { loadNamespace("roxygenlabs"); list(markdown = TRUE) }
-RoxygenNote: 7.1.1.9000
+RoxygenNote: 7.1.1.9001

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,7 @@
 
 # gh development version
 
-* The validation of the token takes into account changes introduced in their
-  formatting. Tokens generated starting on April 1st, 2021 have a prefix and are
-  in the set [A-Za-z0-9_] instead of being hexadecimal digits (#148).
+* Token validation accounts for the new format [announced 2021-03-04 ](https://github.blog/changelog/2021-03-04-authentication-token-format-updates/) and implemented on 2021-04-01 (#148, @fmichonneau).
 
 # gh 1.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # gh development version
 
+* The validation of the token takes into account changes introduced in their
+  formatting. Tokens generated starting on April 1st, 2021 have a prefix and are
+  in the set [A-Za-z0-9_] instead of being hexadecimal digits (#148).
+
 # gh 1.2.0
 
 * `gh_gql()` now passes all arguments to `gh()` (#124).

--- a/R/gh_token.R
+++ b/R/gh_token.R
@@ -78,7 +78,7 @@ validate_gh_pat <- function(x) {
   if (x == "" || grepl("^gh[pousr]_[A-Za-z0-9_]{36}$", x) || grepl("[[:xdigit:]]{40}", x)) {
     x
   } else {
-    throw(new_error("A GitHub PAT must consist of 40 hexadecimal digits"))
+    throw(new_error("A GitHub PAT must consist of 40 characters."))
   }
 }
 

--- a/R/gh_token.R
+++ b/R/gh_token.R
@@ -79,17 +79,25 @@ new_gh_pat <- function(x) {
   if (is.character(x) && length(x) == 1) {
     structure(x, class = "gh_pat")
   } else {
-    throw(new_error("A GitHub PAT must be a string"))
+    throw(new_error("A GitHub PAT must be a string", call. = FALSE))
   }
 }
 
 # validates PAT only in a very narrow, technical, and local sense
 validate_gh_pat <- function(x) {
   stopifnot(inherits(x, "gh_pat"))
-  if (x == "" || grepl("^gh[pousr]_[A-Za-z0-9_]{36,251}$", x) || grepl("[[:xdigit:]]{40}", x)) {
+  if (x == "" ||
+      # https://github.blog/changelog/2021-03-04-authentication-token-format-updates/
+      grepl("^gh[pousr]_[A-Za-z0-9_]{36,251}$", x) ||
+      grepl("[[:xdigit:]]{40}", x)) {
     x
   } else {
-    throw(new_error("A GitHub PAT consists of at least 40 characters."))
+    throw(new_error(
+      "GitHub PAT must have one of these forms:",
+      "\n  * 40 hexadecimal digits (older PATs)",
+      "\n  * A 'ghp_' prefix followed by 36 to 251 more characters (newer PATs)",
+      call. = FALSE
+    ))
   }
 }
 

--- a/R/gh_token.R
+++ b/R/gh_token.R
@@ -126,7 +126,7 @@ str.gh_pat <- function(object, ...) {
   invisible()
 }
 
-obfuscate <- function(x, first = 4, last = 2) {
+obfuscate <- function(x, first = 4, last = 4) {
   paste0(
     substr(x, start = 1, stop = first),
     "...",

--- a/R/gh_token.R
+++ b/R/gh_token.R
@@ -24,17 +24,6 @@
 #' point on, gh (via [gitcreds::gitcreds_get()]) should be able to find it
 #' without further effort on your part.
 #'
-#' Until March 31st, 2021, GitHub tokens were formed by a string of 40
-#' hexadecimal digits. After this date, newly generated tokens start with a
-#' prefix (`ghp_` for personal access tokens), and are composed of lower and
-#' upper case letters as well as digits and underscores. The total length of
-#' tokens remains set at 40 characters. GitHub has indicated that starting in
-#' June 2021, they plan to increase the length of PAT up to 255 characters. gh
-#' validates tokens by checking that they are formed of either 40 hexadecimal
-#' digits, or that they start with a prefix and are between 40 and 255
-#' characters. More information about this change is available on [GitHub's
-#' blog](https://github.blog/changelog/2021-03-04-authentication-token-format-updates/).
-#'
 #' @param api_url GitHub API URL. Defaults to the `GITHUB_API_URL` environment
 #'   variable, if set, and otherwise to <https://api.github.com>.
 #'

--- a/R/gh_token.R
+++ b/R/gh_token.R
@@ -75,7 +75,7 @@ new_gh_pat <- function(x) {
 # validates PAT only in a very narrow, technical, and local sense
 validate_gh_pat <- function(x) {
   stopifnot(inherits(x, "gh_pat"))
-  if (x == "" || grepl("^gh[pousr]_[A-Za-z0-9_]{36}$", x) || grepl("[[:xdigit:]]{40}", x)) {
+  if (x == "" || grepl("^gh[pousr]_[A-Za-z0-9_]{36,251}$", x) || grepl("[[:xdigit:]]{40}", x)) {
     x
   } else {
     throw(new_error("A GitHub PAT must consist of 40 characters."))

--- a/R/gh_token.R
+++ b/R/gh_token.R
@@ -75,7 +75,7 @@ new_gh_pat <- function(x) {
 # validates PAT only in a very narrow, technical, and local sense
 validate_gh_pat <- function(x) {
   stopifnot(inherits(x, "gh_pat"))
-  if (x == "" || grepl("[[:xdigit:]]{40}", x)) {
+  if (x == "" || grepl("^gh[pousr]_[A-Za-z0-9_]{36}$", x) || grepl("[[:xdigit:]]{40}", x)) {
     x
   } else {
     throw(new_error("A GitHub PAT must consist of 40 hexadecimal digits"))

--- a/R/gh_token.R
+++ b/R/gh_token.R
@@ -24,10 +24,21 @@
 #' point on, gh (via [gitcreds::gitcreds_get()]) should be able to find it
 #' without further effort on your part.
 #'
+#' Until March 31st, 2021, GitHub tokens were formed by a string of 40
+#' hexadecimal digits. After this date, newly generated tokens start with a
+#' prefix (`ghp_` for personal access tokens), and are composed of lower and
+#' upper case letters as well as digits and underscores. The total length of
+#' tokens remains set at 40 characters. GitHub has indicated that starting in
+#' June 2021, they plan to increase the length of PAT up to 255 characters. gh
+#' validates tokens by checking that they are formed of either 40 hexadecimal
+#' digits, or that they start with a prefix and are between 40 and 255
+#' characters. More information about this change is available on [GitHub's
+#' blog](https://github.blog/changelog/2021-03-04-authentication-token-format-updates/).
+#'
 #' @param api_url GitHub API URL. Defaults to the `GITHUB_API_URL` environment
 #'   variable, if set, and otherwise to <https://api.github.com>.
 #'
-#' @return A string of 40 hexadecimal digits, if a PAT is found, or the empty
+#' @return A string of characters, if a PAT is found, or the empty
 #'   string, otherwise. For convenience, the return value has an S3 class in
 #'   order to ensure that simple printing strategies don't reveal the entire
 #'   PAT.
@@ -78,7 +89,7 @@ validate_gh_pat <- function(x) {
   if (x == "" || grepl("^gh[pousr]_[A-Za-z0-9_]{36,251}$", x) || grepl("[[:xdigit:]]{40}", x)) {
     x
   } else {
-    throw(new_error("A GitHub PAT must consist of 40 characters."))
+    throw(new_error("A GitHub PAT consists of at least 40 characters."))
   }
 }
 

--- a/R/gh_whoami.R
+++ b/R/gh_whoami.R
@@ -5,10 +5,9 @@
 
 #'
 #' Get a personal access token for the GitHub API from
-#' <https://github.com/settings/tokens> and select the scopes necessary for
-#' your planned tasks. The `repo` scope, for example, is one many are
-#' likely to need. The token itself is a string of 40 letters and digits. You
-#' can store it any way you like and provide explicitly via the `.token`
+#' <https://github.com/settings/tokens> and select the scopes necessary for your
+#' planned tasks. The `repo` scope, for example, is one many are likely to need.
+#' You can store it any way you like and provide explicitly via the `.token`
 #' argument to [gh()].
 #'
 #' However, many prefer to define an environment variable `GITHUB_PAT` (or

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -8,6 +8,7 @@ Minimalistic
 OAuth
 PATs
 URI
+Za
 api
 auth
 discoverable

--- a/man/gh_token.Rd
+++ b/man/gh_token.Rd
@@ -38,16 +38,6 @@ pre-selection of recommended scopes. Once you have a PAT, you can use
 \code{\link[gitcreds:gitcreds_get]{gitcreds::gitcreds_set()}} to add it to the Git credential store. From that
 point on, gh (via \code{\link[gitcreds:gitcreds_get]{gitcreds::gitcreds_get()}}) should be able to find it
 without further effort on your part.
-
-Until March 31st, 2021, GitHub tokens were formed by a string of 40
-hexadecimal digits. After this date, newly generated tokens start with a
-prefix (\code{ghp_} for personal access tokens), and are composed of lower and
-upper case letters as well as digits and underscores. The total length of
-tokens remains set at 40 characters. GitHub has indicated that starting in
-June 2021, they plan to increase the length of PAT up to 255 characters. gh
-validates tokens by checking that they are formed of either 40 hexadecimal
-digits, or that they start with a prefix and are between 40 and 255
-characters. More information about this change is available on \href{https://github.blog/changelog/2021-03-04-authentication-token-format-updates/}{GitHub's blog}.
 }
 \examples{
 \dontrun{

--- a/man/gh_token.Rd
+++ b/man/gh_token.Rd
@@ -11,7 +11,7 @@ gh_token(api_url = NULL)
 variable, if set, and otherwise to \url{https://api.github.com}.}
 }
 \value{
-A string of 40 hexadecimal digits, if a PAT is found, or the empty
+A string of characters, if a PAT is found, or the empty
 string, otherwise. For convenience, the return value has an S3 class in
 order to ensure that simple printing strategies don't reveal the entire
 PAT.
@@ -38,6 +38,16 @@ pre-selection of recommended scopes. Once you have a PAT, you can use
 \code{\link[gitcreds:gitcreds_get]{gitcreds::gitcreds_set()}} to add it to the Git credential store. From that
 point on, gh (via \code{\link[gitcreds:gitcreds_get]{gitcreds::gitcreds_get()}}) should be able to find it
 without further effort on your part.
+
+Until March 31st, 2021, GitHub tokens were formed by a string of 40
+hexadecimal digits. After this date, newly generated tokens start with a
+prefix (\code{ghp_} for personal access tokens), and are composed of lower and
+upper case letters as well as digits and underscores. The total length of
+tokens remains set at 40 characters. GitHub has indicated that starting in
+June 2021, they plan to increase the length of PAT up to 255 characters. gh
+validates tokens by checking that they are formed of either 40 hexadecimal
+digits, or that they start with a prefix and are between 40 and 255
+characters. More information about this change is available on \href{https://github.blog/changelog/2021-03-04-authentication-token-format-updates/}{GitHub's blog}.
 }
 \examples{
 \dontrun{

--- a/man/gh_whoami.Rd
+++ b/man/gh_whoami.Rd
@@ -30,10 +30,9 @@ authenticated user, the first bit of the token, and the associated scopes.
 }
 \details{
 Get a personal access token for the GitHub API from
-\url{https://github.com/settings/tokens} and select the scopes necessary for
-your planned tasks. The \code{repo} scope, for example, is one many are
-likely to need. The token itself is a string of 40 letters and digits. You
-can store it any way you like and provide explicitly via the \code{.token}
+\url{https://github.com/settings/tokens} and select the scopes necessary for your
+planned tasks. The \code{repo} scope, for example, is one many are likely to need.
+You can store it any way you like and provide explicitly via the \code{.token}
 argument to \code{\link[=gh]{gh()}}.
 
 However, many prefer to define an environment variable \code{GITHUB_PAT} (or

--- a/tests/testthat/test-gh_token.R
+++ b/tests/testthat/test-gh_token.R
@@ -60,6 +60,12 @@ test_that("validate_gh_pat() rejects bad characters, wrong # of characters", {
   expect_error(gh_pat(strrep("a", 40)), NA)
   expect_error(gh_pat(strrep("g", 40)), "40 characters", class = "error")
   expect_error(gh_pat("aa"), "40 characters", class = "error")
+
+  expect_match(gh_pat(paste0("ghp_", strrep("a", 36))), "^ghp_")
+  expect_match(gh_pat(paste0("ghp_", strrep("a", 251))), "^ghp_")
+
+  expect_error(gh_pat(paste0("ghx_", strrep("a", 36))), "40 characters", class = "error")
+
 })
 
 test_that("format.gh_pat() and str.gh_pat() hide the middle stuff", {

--- a/tests/testthat/test-gh_token.R
+++ b/tests/testthat/test-gh_token.R
@@ -58,8 +58,8 @@ test_that("fall back to GITHUB_PAT, then GITHUB_TOKEN", {
 # gh_pat class ----
 test_that("validate_gh_pat() rejects bad characters, wrong # of characters", {
   expect_error(gh_pat(strrep("a", 40)), NA)
-  expect_error(gh_pat(strrep("g", 40)), "40 hexadecimal digits", class = "error")
-  expect_error(gh_pat("aa"), "40 hexadecimal digits", class = "error")
+  expect_error(gh_pat(strrep("g", 40)), "40 characters", class = "error")
+  expect_error(gh_pat("aa"), "40 characters", class = "error")
 })
 
 test_that("format.gh_pat() and str.gh_pat() hide the middle stuff", {

--- a/tests/testthat/test-gh_token.R
+++ b/tests/testthat/test-gh_token.R
@@ -57,15 +57,15 @@ test_that("fall back to GITHUB_PAT, then GITHUB_TOKEN", {
 
 # gh_pat class ----
 test_that("validate_gh_pat() rejects bad characters, wrong # of characters", {
+  # older PATs
   expect_error(gh_pat(strrep("a", 40)), NA)
-  expect_error(gh_pat(strrep("g", 40)), "40 characters", class = "error")
-  expect_error(gh_pat("aa"), "40 characters", class = "error")
+  expect_error(gh_pat(strrep("g", 40)), "40 hexadecimal digits", class = "error")
+  expect_error(gh_pat("aa"), "40 hexadecimal digits", class = "error")
 
-  expect_match(gh_pat(paste0("ghp_", strrep("a", 36))), "^ghp_")
-  expect_match(gh_pat(paste0("ghp_", strrep("a", 251))), "^ghp_")
-
-  expect_error(gh_pat(paste0("ghx_", strrep("a", 36))), "40 characters", class = "error")
-
+  # newer PATs
+  expect_error(gh_pat(paste0("ghp_", strrep("B", 36))), NA)
+  expect_error(gh_pat(paste0("ghp_", strrep("3", 251))), NA)
+  expect_error(gh_pat(paste0("ghJ_", strrep("a", 36))), "prefix", class = "error")
 })
 
 test_that("format.gh_pat() and str.gh_pat() hide the middle stuff", {


### PR DESCRIPTION
fix #148 

update the regular expression to match the new token formats.

* Do we want to allow for the non-PAT prefixes? in other words, should only `ghp_` prefixes be allowed? (this PR allows the 5 prefixes mentioned in the [blog post](https://github.blog/changelog/2021-03-04-authentication-token-format-updates/)
* Should [tests](https://github.com/r-lib/gh/blob/master/tests/testthat/test-gh_token.R#L59-L63) be modified to account for this regular expression change?
* Do we want to already allow for up to 255 characters?