### PR TITLE
Update with current errors.R from processx

### DIFF
--- a/R/errors.R
+++ b/R/errors.R
@@ -89,6 +89,10 @@
 # ### 1.2.3 -- 2021-03-06
 #
 # * Use cli instead of crayon
+#
+# ### 1.2.4 -- 2012-04-01
+#
+# * Allow omitting the call with call. = FALSE in `new_cond()`, etc.
 
 err <- local({
 
@@ -101,7 +105,7 @@ err <- local({
   #'   character and then concatenated, like in [stop()].
   #' @param call. A call object to include in the condition, or `TRUE`
   #'   or `NULL`, meaning that [throw()] should add a call object
-  #'   automatically.
+  #'   automatically. If `FALSE`, then no call is added.
   #' @param domain Translation domain, see [stop()].
   #' @return Condition object. Currently a list, but you should not rely
   #'   on that.
@@ -154,6 +158,8 @@ err <- local({
 
     if (isTRUE(cond$call)) {
       cond$call <- sys.call(-1) %||% sys.call()
+    } else if (identical(cond$call, FALSE)) {
+      cond$call <- NULL
     }
 
     # Eventually the nframe numbers will help us print a better trace

--- a/R/errors.R
+++ b/R/errors.R
@@ -22,7 +22,7 @@
 #   the error, e.g. `.Last.error$trace`. The trace of the last error is
 #   also at `.Last.error.trace`.
 # - Can merge errors and traces across multiple processes.
-# - Pretty-print errors and traces, if the crayon package is loaded.
+# - Pretty-print errors and traces, if the cli package is loaded.
 # - Automatically hides uninformative parts of the stack trace when
 #   printing.
 #
@@ -54,6 +54,41 @@
 # ### 1.0.2 -- 2019-06-27
 #
 # * Internal change: change topenv of the functions to baseenv()
+#
+# ### 1.1.0 -- 2019-10-26
+#
+# * Register print methods via onload_hook() function, call from .onLoad()
+# * Print the error manually, and the trace in non-interactive sessions
+#
+# ### 1.1.1 -- 2019-11-10
+#
+# * Only use `trace` in parent errors if they are `rlib_error`s.
+#   Because e.g. `rlang_error`s also have a trace, with a slightly
+#   different format.
+#
+# ### 1.2.0 -- 2019-11-13
+#
+# * Fix the trace if a non-thrown error is re-thrown.
+# * Provide print_this() and print_parents() to make it easier to define
+#   custom print methods.
+# * Fix annotating our throw() methods with the incorrect `base::`.
+#
+# ### 1.2.1 -- 2020-01-30
+#
+# * Update wording of error printout to be less intimidating, avoid jargon
+# * Use default printing in interactive mode, so RStudio can detect the
+#   error and highlight it.
+# * Add the rethrow_call_with_cleanup function, to work with embedded
+#   cleancall.
+#
+# ### 1.2.2 -- 2020-11-19
+#
+# * Add the `call` argument to `catch_rethrow()` and `rethrow()`, to be
+#   able to omit calls.
+#
+# ### 1.2.3 -- 2021-03-06
+#
+# * Use cli instead of crayon
 
 err <- local({
 
@@ -117,7 +152,7 @@ err <- local({
       throw(new_error("Parent condition must be a condition object"))
     }
 
-    if (is.null(cond$call) || isTRUE(cond$call)) {
+    if (isTRUE(cond$call)) {
       cond$call <- sys.call(-1) %||% sys.call()
     }
 
@@ -149,7 +184,9 @@ err <- local({
 
     # If we get here that means that the condition was not caught by
     # an exiting handler. That means that we need to create a trace.
-    cond <- add_trace_back(cond)
+    # If there is a hand-constructed trace already in the error object,
+    # then we'll just leave it there.
+    if (is.null(cond$trace)) cond <- add_trace_back(cond)
 
     # Set up environment to store .Last.error, it will be just before
     # baseenv(), so it is almost as if it was in baseenv() itself, like
@@ -160,8 +197,6 @@ err <- local({
                              name = "org:r-lib"))
     }
     env <- as.environment("org:r-lib")
-    env$print.rlib_error <- print_rlib_error
-    env$print.rlib_trace <- print_rlib_trace
     env$.Last.error <- cond
     env$.Last.error.trace <- cond$trace
 
@@ -175,6 +210,45 @@ err <- local({
       th(cond)
 
     } else {
+
+      if (is_interactive()) {
+        # In interactive mode, we print the error message through
+        # conditionMessage() and also add a note about .Last.error.trace.
+        # R will potentially truncate the error message, so we make sure
+        # that the note is shown. Ideally we would print the error
+        # ourselves, but then RStudio would not highlight it.
+        max_msg_len <- as.integer(getOption("warning.length"))
+        if (is.na(max_msg_len)) max_msg_len <- 1000
+        msg <- conditionMessage(cond)
+        adv <- style_advice(
+          "\nType .Last.error.trace to see where the error occured"
+        )
+        dots <- "\033[0m\n[...]"
+        if (bytes(msg) + bytes(adv) + bytes(dots) + 5L> max_msg_len) {
+          msg <- paste0(
+            substr(msg, 1, max_msg_len - bytes(dots) - bytes(adv) - 5L),
+            dots
+          )
+        }
+        cond$message <- paste0(msg, adv)
+
+      } else {
+        # In non-interactive mode, we print the error + the traceback
+        # manually, to make sure that it won't be truncated by R's error
+        # message length limit.
+        cat("\n", file = stderr())
+        cat(style_error(gettext("Error: ")), file = stderr())
+        out <- capture_output(print(cond))
+        cat(out, file = stderr(), sep = "\n")
+        out <- capture_output(print(cond$trace))
+        cat(out, file = stderr(), sep = "\n")
+
+        # Turn off the regular error printing to avoid printing
+        # the error twice.
+        opts <- options(show.error.messages = FALSE)
+        on.exit(options(opts), add = TRUE)
+      }
+
       # Dropping the classes and adding "duplicate_condition" is a workaround
       # for the case when we have non-exiting handlers on throw()-n
       # conditions. These would get the condition twice, because stop()
@@ -183,6 +257,7 @@ err <- local({
       # This is probably quite rare, but for this rare case they can also
       # recognize the duplicates from the "duplicate_condition" extra class.
       class(cond) <- c("duplicate_condition", "condition")
+
       stop(cond)
     }
   }
@@ -200,6 +275,8 @@ err <- local({
   #'   [withCallingHandlers()]. You are supposed to call [throw()] from
   #'   the error handler, with a new error object, setting the original
   #'   error object as parent. See examples below.
+  #' @param call Logical flag, whether to add the call to
+  #'   `catch_rethrow()` to the error.
   #' @examples
   #' f <- function() {
   #'   ...
@@ -211,8 +288,8 @@ err <- local({
   #'   )
   #' }
 
-  catch_rethrow <- function(expr, ...) {
-    realcall <- sys.call(-1) %||% sys.call()
+  catch_rethrow <- function(expr, ..., call = TRUE) {
+    realcall <- if (isTRUE(call)) sys.call(-1) %||% sys.call()
     realframe <- sys.nframe()
     parent <- parent.frame()
 
@@ -222,7 +299,7 @@ err <- local({
     for (h in names(handlers)) {
       cl[[h]] <- function(e) {
         # This will be NULL if the error is not throw()-n
-        if (is.null(e$`_nframe`)) e$`_nframe` <- sys.parent()
+        if (is.null(e$`_nframe`)) e$`_nframe` <- length(sys.calls())
         e$`_childcall` <- realcall
         e$`_childframe` <- realframe
         # We drop after realframe, until the first withCallingHandlers
@@ -250,15 +327,17 @@ err <- local({
   #' @param expr Expression to evaluate.
   #' @param ... Condition handler specification, the same way as in
   #'   [withCallingHandlers()].
+  #' @param call Logical flag, whether to add the call to
+  #'   `rethrow()` to the error.
 
-  rethrow <- function(expr, cond) {
-    realcall <- sys.call(-1) %||% sys.call()
+  rethrow <- function(expr, cond, call = TRUE) {
+    realcall <- if (isTRUE(call)) sys.call(-1) %||% sys.call()
     realframe <- sys.nframe()
     withCallingHandlers(
       expr,
       error = function(e) {
         # This will be NULL if the error is not throw()-n
-        if (is.null(e$`_nframe`)) e$`_nframe` <- sys.parent()
+        if (is.null(e$`_nframe`)) e$`_nframe` <- length(sys.calls())
         e$`_childcall` <- realcall
         e$`_childframe` <- realframe
         # We just ignore the withCallingHandlers call, and the tail
@@ -299,6 +378,37 @@ err <- local({
     )
   }
 
+  package_env <- topenv()
+
+  #' Version of rethrow_call that supports cleancall
+  #'
+  #' This function is the same as [rethrow_call()], except that it
+  #' uses cleancall's [.Call()] wrapper, to enable resource cleanup.
+  #' See https://github.com/r-lib/cleancall#readme for more about
+  #' resource cleanup.
+  #'
+  #' @noRd
+  #' @param .NAME Compiled function to call, see [.Call()].
+  #' @param ... Function arguments, see [.Call()].
+  #' @return Result of the call.
+
+  rethrow_call_with_cleanup <- function(.NAME, ...) {
+    call <- sys.call()
+    nframe <- sys.nframe()
+    withCallingHandlers(
+      package_env$call_with_cleanup(.NAME, ...),
+      error = function(e) {
+        e$`_nframe` <- nframe
+        e$call <- call
+        if (inherits(e, "simpleError")) {
+          class(e) <- c("c_error", "rlib_error", "error", "condition")
+        }
+        e$`_ignore` <- list(c(nframe + 1L, sys.nframe() + 1L))
+        throw(e)
+      }
+    )
+  }
+
   # -- create traceback -------------------------------------------------
 
   #' Create a traceback
@@ -319,7 +429,7 @@ err <- local({
     envs <- lapply(frames, env_label)
     topenvs <- lapply(
       seq_along(frames),
-      function(i) env_label(topenv(environment(sys.function(i)))))
+      function(i) env_label(topenvx(environment(sys.function(i)))))
     nframes <- if (!is.null(cond$`_nframe`)) cond$`_nframe` else sys.parent()
     messages <- list(conditionMessage(cond))
     ignore <- cond$`_ignore`
@@ -329,9 +439,11 @@ err <- local({
     if (is.null(cond$parent)) {
       # Nothing to do, no parent
 
-    } else if (is.null(cond$parent$trace)) {
+    } else if (is.null(cond$parent$trace) ||
+               !inherits(cond$parent, "rlib_error")) {
       # If the parent does not have a trace, that means that it is using
-      # the same trace as us.
+      # the same trace as us. We ignore traces from non-r-lib errors.
+      # E.g. rlang errors have a trace, but we do not use that.
       parent <- cond
       while (!is.null(parent <- parent$parent)) {
         nframes <- c(nframes, parent$`_nframe`)
@@ -361,6 +473,10 @@ err <- local({
     cond
   }
 
+  topenvx <- function(x) {
+    topenv(x, matchThisEnv = err_env)
+  }
+
   new_trace <- function (calls, parents, envs, topenvs, nframes, messages,
                          ignore, classes, pids) {
     indices <- seq_along(calls)
@@ -386,6 +502,9 @@ err <- local({
   }
 
   env_name <- function(env) {
+    if (identical(env, err_env)) {
+      return("")
+    }
     if (identical(env, globalenv())) {
       return("global")
     }
@@ -404,8 +523,7 @@ err <- local({
 
   # -- printing ---------------------------------------------------------
 
-  print_rlib_error <- function(x, ...) {
-
+  print_this <- function(x, ...) {
     msg <- conditionMessage(x)
     call <- conditionCall(x)
     cl <- class(x)[1L]
@@ -421,22 +539,29 @@ err <- local({
       cat(" in process", x$`_pid`, "\n")
     }
 
+    invisible(x)
+  }
+
+  print_parents <- function(x, ...) {
     if (!is.null(x$parent)) {
       cat("-->\n")
       print(x$parent)
     }
-
     invisible(x)
   }
 
+  print_rlib_error <- function(x, ...) {
+    print_this(x, ...)
+    print_parents(x, ...)
+  }
+
   print_rlib_trace <- function(x, ...) {
-    cl <- setdiff(x$classes, c("error", "condition"))
-    cl <- paste0(" ERROR TRACE for ", paste(cl, collapse = ", "), "")
+    cl <- paste0(" Stack trace:")
     cat(sep = "", "\n", style_trace_title(cl), "\n\n")
     calls <- map2(x$calls, x$topenv, namespace_calls)
     callstr <- vapply(calls, format_call_src, character(1))
     callstr[x$nframes] <-
-      paste0(callstr[x$nframes], "\n", style_error(x$messages), "\n")
+      paste0(callstr[x$nframes], "\n", style_error_msg(x$messages), "\n")
     callstr <- enumerate(callstr)
 
     # Ignore what we were told to ignore
@@ -466,6 +591,46 @@ err <- local({
 
     cat(callstr, sep = "\n")
     invisible(x)
+  }
+
+  capture_output <- function(expr) {
+    if (has_cli()) {
+      opts <- options(cli.num_colors = cli::num_ansi_colors())
+      on.exit(options(opts), add = TRUE)
+    }
+
+    out <- NULL
+    file <- textConnection("out", "w", local = TRUE)
+    sink(file)
+    on.exit(sink(NULL), add = TRUE)
+
+    expr
+    if (is.null(out)) invisible(NULL) else out
+  }
+
+  is_interactive <- function() {
+    opt <- getOption("rlib_interactive")
+    if (isTRUE(opt)) {
+      TRUE
+    } else if (identical(opt, FALSE)) {
+      FALSE
+    } else if (tolower(getOption("knitr.in.progress", "false")) == "true") {
+      FALSE
+    } else if (tolower(getOption("rstudio.notebook.executing", "false")) == "true") {
+      FALSE
+    } else if (identical(Sys.getenv("TESTTHAT"), "true")) {
+      FALSE
+    } else {
+      interactive()
+    }
+  }
+
+  onload_hook <- function() {
+    reg_env <- Sys.getenv("R_LIB_ERROR_REGISTER_PRINT_METHODS", "TRUE")
+    if (tolower(reg_env) != "false") {
+      registerS3method("print", "rlib_error", print_rlib_error, baseenv())
+      registerS3method("print", "rlib_trace", print_rlib_trace, baseenv())
+    }
   }
 
   namespace_calls <- function(call, env) {
@@ -531,52 +696,67 @@ err <- local({
            USE.NAMES = FALSE)
   }
 
+  bytes <- function(x) {
+    nchar(x, type = "bytes")
+  }
+
   # -- printing, styles -------------------------------------------------
 
-  has_crayon <- function() "crayon" %in% loadedNamespaces()
+  has_cli <- function() "cli" %in% loadedNamespaces()
 
   style_numbers <- function(x) {
-    if (has_crayon()) crayon::silver(x) else x
+    if (has_cli()) cli::col_silver(x) else x
+  }
+
+  style_advice <- function(x) {
+    if (has_cli()) cli::col_silver(x) else x
   }
 
   style_srcref <- function(x) {
-    if (has_crayon()) crayon::italic(crayon::cyan(x))
+    if (has_cli()) cli::style_italic(cli::col_cyan(x))
   }
 
   style_error <- function(x) {
+    if (has_cli()) cli::style_bold(cli::col_ed(x)) else x
+  }
+
+  style_error_msg <- function(x) {
     sx <- paste0("\n x ", x, " ")
-    if (has_crayon()) crayon::bold(crayon::red(sx)) else sx
+    style_error(sx)
   }
 
   style_trace_title <- function(x) {
-    if (has_crayon()) crayon::bold(x) else x
+    x
   }
 
   style_process <- function(x) {
-    if (has_crayon()) crayon::bold(x) else x
+    if (has_cli()) cli::style_bold(x) else x
   }
 
   style_call <- function(x) {
-    if (!has_crayon()) return(x)
+    if (!has_cli()) return(x)
     call <- sub("^([^(]+)[(].*$", "\\1", x)
     rest <- sub("^[^(]+([(].*)$", "\\1", x)
     if (call == x || rest == x) return(x)
-    paste0(crayon::yellow(call), rest)
+    paste0(cli::col_yellow(call), rest)
   }
 
-  env <- environment()
-  parent.env(env) <- baseenv()
+  err_env <- environment()
+  parent.env(err_env) <- baseenv()
 
   structure(
     list(
-      .internal      = env,
+      .internal      = err_env,
       new_cond       = new_cond,
       new_error      = new_error,
       throw          = throw,
       rethrow        = rethrow,
       catch_rethrow  = catch_rethrow,
       rethrow_call   = rethrow_call,
-      add_trace_back = add_trace_back
+      add_trace_back = add_trace_back,
+      onload_hook    = onload_hook,
+      print_this     = print_this,
+      print_parents  = print_parents
     ),
     class = c("standalone_errors", "standalone"))
 })
@@ -589,3 +769,4 @@ new_error <- err$new_error
 throw     <- err$throw
 rethrow   <- err$rethrow
 rethrow_call <- err$rethrow_call
+rethrow_call_with_cleanup <- err$.internal$rethrow_call_with_cleanup


### PR DESCRIPTION
I did this because it feels like `call.` does not have the usual effect. I figured this has since been fixed in the compat file. But even after I update, `call.` doesn't work the way I expect.

Is this expected behaviour? I'm talking about the `Error in FALSE` part.

``` r
gh:::gh_pat("aa")
#> Error in FALSE: GitHub PAT must have one of these forms:
#>   * 40 hexadecimal digits (older PATs)
#>   * A 'ghp_' prefix followed by 36 to 251 more characters (newer PATs)
```

<sup>Created on 2021-04-01 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0.9002)</sup>

Generated by https://github.com/r-lib/gh/blob/86eb3d975bef9133b62c82176c2d893ddb4110da/R/gh_token.R#L84-L89