### PR TITLE
Add support for fine-grained PATs (#171)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # gh (development version)
 
+* gh can now validate GitHub
+  [fine-grained](https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/)
+  personal access tokens (@jvstein, #171).
+
 # gh 1.3.1
 
 * gh now accepts lower-case methods i.e. both `gh::gh("get /users/hadley/repos")` and `gh::gh("GET /users/hadley/repos")` work (@maelle, #167).

--- a/R/gh_token.R
+++ b/R/gh_token.R
@@ -77,16 +77,19 @@ validate_gh_pat <- function(x) {
   stopifnot(inherits(x, "gh_pat"))
   if (x == "" ||
     # https://github.blog/changelog/2021-03-04-authentication-token-format-updates/
-    grepl("^gh[pousr]_[A-Za-z0-9_]{36,251}$", x) ||
-    grepl("[[:xdigit:]]{40}", x)) {
+    # Fine grained tokens start with "github_pat_".
+    # https://github.blog/changelog/2022-10-18-introducing-fine-grained-personal-access-tokens/
+    grepl("^(gh[pousr]_[A-Za-z0-9_]{36,251}|github_pat_[A-Za-z0-9_]{36,244})$", x) ||
+    grepl("^[[:xdigit:]]{40}$", x)) {
     x
   } else {
     url <- "https://gh.r-lib.org/articles/managing-personal-access-tokens.html"
     cli::cli_abort(c(
       "Invalid GitHub PAT format",
-      "i" = "A GitHub PAT must have one of two forms:",
+      "i" = "A GitHub PAT must have one of three forms:",
       "*" = "40 hexadecimal digits (older PATs)",
       "*" = "A 'ghp_' prefix followed by 36 to 251 more characters (newer PATs)",
+      "*" = "A 'github_pat_' prefix followed by 36 to 244 more characters (fine-grained PATs)",
       "i" = "Read more at {.url {url}}."
     ))
   }

--- a/tests/testthat/test-gh_token.R
+++ b/tests/testthat/test-gh_token.R
@@ -65,7 +65,10 @@ test_that("validate_gh_pat() rejects bad characters, wrong # of characters", {
   # newer PATs
   expect_error(gh_pat(paste0("ghp_", strrep("B", 36))), NA)
   expect_error(gh_pat(paste0("ghp_", strrep("3", 251))), NA)
+  expect_error(gh_pat(paste0("github_pat_", strrep("A", 36))), NA)
+  expect_error(gh_pat(paste0("github_pat_", strrep("3", 244))), NA)
   expect_error(gh_pat(paste0("ghJ_", strrep("a", 36))), "prefix", class = "error")
+  expect_error(gh_pat(paste0("github_pa_", strrep("B", 244))), "github_pat_", class = "error")
 })
 
 test_that("format.gh_pat() and str.gh_pat() hide the middle stuff", {


### PR DESCRIPTION
Add support for the new token format for [fine-grained PATs](https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/).

The new tokens start with "github_pat_" prefix, but are subject to change according to the announcement.