### PR TITLE
Implement request_throttling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # gh (development version)
 
+* `gh()` gains a new `.max_rate` parameter that sets the maximum number of 
+  requests per second.
+
 * gh is now powered by httr2. This should generally have little impact on normal
   operation but if a request fails, you can use `httr2::last_response()` and 
   `httr2::last_request()` to debug.

--- a/R/gh_request.R
+++ b/R/gh_request.R
@@ -14,6 +14,7 @@ gh_build_request <- function(endpoint = "/user",
                              accept = NULL,
                              send_headers = NULL,
                              max_wait = 10,
+                             max_rate = NULL,
                              api_url = NULL,
                              method = "GET") {
   working <- list(
@@ -30,7 +31,8 @@ gh_build_request <- function(endpoint = "/user",
     api_url = api_url,
     dest = destfile,
     overwrite = overwrite,
-    max_wait = max_wait
+    max_wait = max_wait,
+    max_rate = max_rate
   )
 
   working <- gh_set_verb(working)
@@ -39,7 +41,7 @@ gh_build_request <- function(endpoint = "/user",
   working <- gh_set_body(working)
   working <- gh_set_url(working)
   working <- gh_set_headers(working)
-  working[c("method", "url", "headers", "query", "body", "dest")]
+  working[c("method", "url", "headers", "query", "body", "dest", "max_wait", "max_rate")]
 }
 
 

--- a/R/gh_response.R
+++ b/R/gh_response.R
@@ -27,6 +27,10 @@ gh_process_response <- function(resp, gh_req) {
   attr(res, "response") <- httr2::resp_headers(resp)
   attr(res, "request") <- gh_req
 
+  # for backward compatibility
+  attr(res, "method") <- resp$method
+  attr(res, ".send_headers") <- httr2::last_request()$headers
+
   if (is_ondisk) {
     class(res) <- c("gh_response", "path")
   } else if (is_raw) {

--- a/R/gh_response.R
+++ b/R/gh_response.R
@@ -1,4 +1,4 @@
-gh_process_response <- function(resp) {
+gh_process_response <- function(resp, gh_req) {
   stopifnot(inherits(resp, "httr2_response"))
 
   content_type <- httr2::resp_content_type(resp)
@@ -24,9 +24,8 @@ gh_process_response <- function(resp) {
     res <- list(message = httr2::resp_body_string(resp))
   }
 
-  attr(res, "method") <- resp$method
   attr(res, "response") <- httr2::resp_headers(resp)
-  attr(res, ".send_headers") <- httr2::last_request()$headers
+  attr(res, "request") <- gh_req
 
   if (is_ondisk) {
     class(res) <- c("gh_response", "path")

--- a/R/pagination.R
+++ b/R/pagination.R
@@ -39,17 +39,15 @@ gh_link_request <- function(gh_response, link) {
   url <- extract_link(gh_response, link)
   if (is.na(url)) cli::cli_abort("No {link} page")
 
-  list(
-    method = attr(gh_response, "method"),
-    url = url,
-    headers = attr(gh_response, ".send_headers")
-  )
+  req <- attr(gh_response, "request")
+  req$url <- url
+  req
 }
 
 gh_link <- function(gh_response, link) {
   req <- gh_link_request(gh_response, link)
   raw <- gh_make_request(req)
-  gh_process_response(raw)
+  gh_process_response(raw, req)
 }
 
 gh_extract_pages <- function(gh_response) {

--- a/R/print.R
+++ b/R/print.R
@@ -11,9 +11,8 @@
 
 print.gh_response <- function(x, ...) {
   if (inherits(x, c("raw", "path"))) {
-    attr(x, c("method")) <- NULL
+    attr(x, c("request")) <- NULL
     attr(x, c("response")) <- NULL
-    attr(x, ".send_headers") <- NULL
     print.default(x)
   } else {
     print(toJSON(unclass(x), pretty = TRUE, auto_unbox = TRUE, force = TRUE))

--- a/R/print.R
+++ b/R/print.R
@@ -11,12 +11,7 @@
 
 print.gh_response <- function(x, ...) {
   if (inherits(x, c("raw", "path"))) {
-    attr(x, c("request")) <- NULL
-    attr(x, c("response")) <- NULL
-
-    attr(x, ".send_headers") <- NULL
-    attr(x, "method") <- NULL
-
+    attributes(x) <- list(class = class(x))
     print.default(x)
   } else {
     print(toJSON(unclass(x), pretty = TRUE, auto_unbox = TRUE, force = TRUE))

--- a/R/print.R
+++ b/R/print.R
@@ -13,6 +13,10 @@ print.gh_response <- function(x, ...) {
   if (inherits(x, c("raw", "path"))) {
     attr(x, c("request")) <- NULL
     attr(x, c("response")) <- NULL
+
+    attr(x, ".send_headers") <- NULL
+    attr(x, "method") <- NULL
+
     print.default(x)
   } else {
     print(toJSON(unclass(x), pretty = TRUE, auto_unbox = TRUE, force = TRUE))

--- a/man/gh.Rd
+++ b/man/gh.Rd
@@ -18,7 +18,8 @@ gh(
   .send_headers = NULL,
   .progress = TRUE,
   .params = list(),
-  .max_wait = 600
+  .max_wait = 600,
+  .max_rate = NULL
 )
 }
 \arguments{
@@ -94,6 +95,9 @@ a list already.}
 
 \item{.max_wait}{Maximum number of seconds to wait if rate limited.
 Defaults to 10 minutes.}
+
+\item{.max_rate}{Maximum request rate in requests per second. Set
+this to automatically throttle requests.}
 }
 \value{
 Answer from the API as a \code{gh_response} object, which is also a

--- a/tests/testthat/_snaps/print.md
+++ b/tests/testthat/_snaps/print.md
@@ -1,0 +1,39 @@
+# can print all types of object
+
+    Code
+      json
+    Output
+      {
+        "name": "LICENSE",
+        "path": "LICENSE",
+        "sha": "c71242092c79fcc895841ca3e7de5bbcc551cde5",
+        "size": 81,
+        "url": "https://api.github.com/repos/r-lib/gh/contents/LICENSE?ref=v1.2.0",
+        "html_url": "https://github.com/r-lib/gh/blob/v1.2.0/LICENSE",
+        "git_url": "https://api.github.com/repos/r-lib/gh/git/blobs/c71242092c79fcc895841ca3e7de5bbcc551cde5",
+        "download_url": "https://raw.githubusercontent.com/r-lib/gh/v1.2.0/LICENSE",
+        "type": "file",
+        "content": "WUVBUjogMjAxNS0yMDIwCkNPUFlSSUdIVCBIT0xERVI6IEfDoWJvciBDc8Oh\ncmRpLCBKZW5uaWZlciBCcnlhbiwgSGFkbGV5IFdpY2toYW0K\n",
+        "encoding": "base64",
+        "_links": {
+          "self": "https://api.github.com/repos/r-lib/gh/contents/LICENSE?ref=v1.2.0",
+          "git": "https://api.github.com/repos/r-lib/gh/git/blobs/c71242092c79fcc895841ca3e7de5bbcc551cde5",
+          "html": "https://github.com/r-lib/gh/blob/v1.2.0/LICENSE"
+        }
+      } 
+    Code
+      file
+    Output
+      [1] "LICENSE"
+      attr(,"class")
+      [1] "gh_response" "path"       
+    Code
+      raw
+    Output
+       [1] 59 45 41 52 3a 20 32 30 31 35 2d 32 30 32 30 0a 43 4f 50 59 52 49 47 48 54
+      [26] 20 48 4f 4c 44 45 52 3a 20 47 c3 a1 62 6f 72 20 43 73 c3 a1 72 64 69 2c 20
+      [51] 4a 65 6e 6e 69 66 65 72 20 42 72 79 61 6e 2c 20 48 61 64 6c 65 79 20 57 69
+      [76] 63 6b 68 61 6d 0a
+      attr(,"class")
+      [1] "gh_response" "raw"        
+

--- a/tests/testthat/test-gh_response.R
+++ b/tests/testthat/test-gh_response.R
@@ -54,3 +54,16 @@ test_that("warns if output is HTML", {
   expect_equal(res, list(message = "<p>foo</p>\n"), ignore_attr = TRUE)
   expect_equal(class(res), c("gh_response", "list"))
 })
+
+test_that("captures details to recreate request", {
+  res <- gh("/orgs/{org}/repos", org = "r-lib", .per_page = 1)
+
+  req <- attr(res, "request")
+  expect_type(req, "list")
+  expect_equal(req$url, "https://api.github.com/orgs/r-lib/repos")
+  expect_equal(req$query, list(.per_page = 1))
+
+  # For backwards compatibility
+  expect_equal(attr(res, "method"), "GET")
+  expect_type(attr(res, ".send_headers"), "list")
+})

--- a/tests/testthat/test-pagination.R
+++ b/tests/testthat/test-pagination.R
@@ -1,0 +1,10 @@
+test_that("paginated request gets max_wait and max_rate", {
+  gh <- gh("/orgs/tidyverse/repos", per_page = 5, .max_wait = 1, .max_rate = 10)
+
+  req <- gh_link_request(gh, "next")
+  expect_equal(req$max_wait, 1)
+  expect_equal(req$max_rate, 10)
+
+  url <- httr2::url_parse(req$url)
+  expect_equal(url$query$page, "2")
+})

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -1,0 +1,29 @@
+test_that("can print all types of object", {
+  get_license <- function(...) {
+    gh(
+      "GET /repos/{owner}/{repo}/contents/{path}",
+      owner = "r-lib",
+      repo = "gh",
+      path = "LICENSE",
+      ref = "v1.2.0",
+      ...
+    )
+  }
+
+  json <- get_license()
+  raw <- get_license(
+    .send_headers = c(Accept = "application/vnd.github.v3.raw")
+  )
+
+  path <- withr::local_file(test_path("LICENSE"))
+  file <- get_license(
+    .destfile = path,
+    .send_headers = c(Accept = "application/vnd.github.v3.raw")
+  )
+
+  expect_snapshot({
+    json
+    file
+    raw
+  })
+})


### PR DESCRIPTION
Testing this revealed that I failed to set up `max_wait` correctly; it got discarded by the final line of `gh_build_request()`. And even if I had caught that, it still wasn't recorded in the response object so pagination could preserve the value.

So now the request captures the complete request list made up by gh and reuses that when paginating. I'll probably refactor this in the future to reuse the same httr2 request.