### PR TITLE
Document that PATs can now expire w/ add default expiration

### DIFF
--- a/vignettes/managing-personal-access-tokens.Rmd
+++ b/vignettes/managing-personal-access-tokens.Rmd
@@ -29,6 +29,7 @@ This article describes how to store your PAT, so that gh can find it (automatica
 More resources on PAT management:
 
   * GitHub documentation on [Creating a personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)
+    - Important: a PAT can expire, the default expiration date is 30 days. 
   * In the [usethis package](https://usethis.r-lib.org):
     - Vignette: [Managing Git(Hub) Credentials](https://usethis.r-lib.org/articles/articles/git-credentials.html) 
     - `usethis::gh_token_help()` and `usethis::git_sitrep()` help you check if


### PR DESCRIPTION
Document that PATs can now expire and the default expiration time is 30 days #160