### PR TITLE
refactor gh::gh parameter handling to make testable without mocking

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Imports:
 Suggests:
     covr,
     knitr,
-    mockery,
     rmarkdown,
     rprojroot,
     spelling,

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 * When the user sets `.destfile` to write the response to disk, gh now
   writes the output to a temporary file, which is then renamed to
   `.destfile` after performing the request, or deleted on error (#178).
+  
+* Removes usage of mockery (#197)
 
 # gh 1.4.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gh (development version)
 
+* Removes usage of mockery (@tanho63, #197)
+
 # gh 1.4.1
 
 * `gh_next()`, `gh_prev()`, `gh_first()` and `gh_last()`
@@ -8,8 +10,6 @@
 * When the user sets `.destfile` to write the response to disk, gh now
   writes the output to a temporary file, which is then renamed to
   `.destfile` after performing the request, or deleted on error (#178).
-  
-* Removes usage of mockery (#197)
 
 # gh 1.4.0
 

--- a/R/gh.R
+++ b/R/gh.R
@@ -172,9 +172,8 @@ gh <- function(endpoint,
                .params = list(),
                .max_wait = 600,
                .max_rate = NULL) {
-  params <- c(list(...), .params)
-  params <- drop_named_nulls(params)
 
+  params <- .parse_params(..., .params)
 
   check_exclusive(per_page, .per_page, .require = FALSE)
   per_page <- per_page %||% .per_page

--- a/R/gh.R
+++ b/R/gh.R
@@ -173,7 +173,7 @@ gh <- function(endpoint,
                .max_wait = 600,
                .max_rate = NULL) {
 
-  params <- .parse_params(..., .params)
+  params <- .parse_params(..., .params = .params)
 
   check_exclusive(per_page, .per_page, .require = FALSE)
   per_page <- per_page %||% .per_page

--- a/R/utils.R
+++ b/R/utils.R
@@ -76,6 +76,12 @@ drop_named_nulls <- function(x) {
   cleanse_names(x[!named | !null])
 }
 
+.parse_params <- function(..., .params = list()) {
+  params <- c(list(...), .params)
+  params <- drop_named_nulls(params)
+  return(params)
+}
+
 check_named_nas <- function(x) {
   if (has_no_names(x)) {
     return(x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -78,8 +78,7 @@ drop_named_nulls <- function(x) {
 
 .parse_params <- function(..., .params = list()) {
   params <- c(list(...), .params)
-  params <- drop_named_nulls(params)
-  return(params)
+  drop_named_nulls(params)
 }
 
 check_named_nas <- function(x) {

--- a/tests/testthat/test-gh.R
+++ b/tests/testthat/test-gh.R
@@ -1,35 +1,3 @@
-
-test_that(".params works", {
-  reqs <- list()
-  testthat::local_mocked_bindings(
-    gh_build_request = function(...) {
-      reqs <<- c(reqs, list(gh_build_request(...)))
-      stop("just this")
-    }
-  )
-
-  expect_error(
-    gh("POST /repos/:org/:repo/issues/:number/labels",
-      org = "ORG", repo = "REPO", number = "1"
-    )
-  )
-
-  expect_error(
-    gh("POST /repos/:org/:repo/issues/:number/labels",
-      org = "ORG", repo = "REPO", .params = list(number = "1")
-    )
-  )
-
-  expect_error(
-    gh("POST /repos/:org/:repo/issues/:number/labels",
-      .params = list(org = "ORG", repo = "REPO", number = "1")
-    )
-  )
-
-  expect_identical(reqs[[1]], reqs[[2]])
-  expect_identical(reqs[[2]], reqs[[3]])
-})
-
 test_that("generates a useful message", {
   skip_if_no_github()
 

--- a/tests/testthat/test-gh.R
+++ b/tests/testthat/test-gh.R
@@ -1,10 +1,12 @@
 
 test_that(".params works", {
   reqs <- list()
-  mockery::stub(gh, "gh_build_request", function(...) {
-    reqs <<- c(reqs, list(gh_build_request(...)))
-    stop("just this")
-  })
+  testthat::local_mocked_bindings(
+    gh_build_request = function(...) {
+      reqs <<- c(reqs, list(gh_build_request(...)))
+      stop("just this")
+    }
+  )
 
   expect_error(
     gh("POST /repos/:org/:repo/issues/:number/labels",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -67,3 +67,15 @@ test_that("named NA is error", {
     expect_error(check_named_nas(tc))
   }
 })
+
+
+test_that(".parse_params combines list .params with ... params", {
+  params <- list(
+    .parse_params(org = "ORG", repo = "REPO", number = "1"),
+    .parse_params(org = "ORG", repo = "REPO", .params = list(number = "1")),
+    .parse_params(.params = list(org = "ORG", repo = "REPO", number = "1"))
+  )
+
+  expect_identical(params[[1]], params[[2]])
+  expect_identical(params[[2]], params[[3]])
+})


### PR DESCRIPTION
Closes #197. 

Original issue suggested replacing mockery with `testthat::with_mock`, however the usage of mockery was to test parameter handling (accepting via both ... and a .params arg) so naive replacement caused an infinitely recursive call to gh_build_request. 

Resolved by refactoring parameter handling into its own function, `.parse_params()`, which is easier to test conventionally