### PR TITLE
Use httr2 cache

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # gh (development version)
 
+* `gh()` now uses a cache provided by httr2. This cache lives in `tools::R_user_dir("gh", "cache")`, maxes out at 100 MB, and can be disabled by setting `options(gh_cache = FALSE)` (#203).
 * Removes usage of mockery (@tanho63, #197)
 
 # gh 1.4.1

--- a/R/gh.R
+++ b/R/gh.R
@@ -287,6 +287,8 @@ gh_make_request <- function(x, error_call = caller_env()) {
   }
   req <- httr2::req_headers(req, !!!x$headers)
 
+  req <- httr2::req_cache(req, path = tools::R_user_dir("gh", "cache"))
+
   if (!is_testing()) {
     req <- httr2::req_retry(
       req,

--- a/R/gh.R
+++ b/R/gh.R
@@ -306,7 +306,7 @@ gh_make_request <- function(x, error_call = caller_env()) {
   req <- httr2::req_error(req, is_error = function(resp) FALSE)
 
   resp <- httr2::req_perform(req, path = x$desttmp)
-  if (httr2::resp_status(resp) >= 300) {
+  if (httr2::resp_status(resp) >= 400) {
     gh_error(resp, gh_req = x, error_call = error_call)
   }
 

--- a/R/gh.R
+++ b/R/gh.R
@@ -287,7 +287,13 @@ gh_make_request <- function(x, error_call = caller_env()) {
   }
   req <- httr2::req_headers(req, !!!x$headers)
 
-  req <- httr2::req_cache(req, path = tools::R_user_dir("gh", "cache"))
+  if (!isFALSE(getOption("gh_cache"))) {
+    req <- httr2::req_cache(
+      req,
+      max_size = 100 * 1024 * 1024, # 100 MB
+      path = tools::R_user_dir("gh", "cache")
+    )
+  }
 
   if (!is_testing()) {
     req <- httr2::req_retry(

--- a/R/gh_response.R
+++ b/R/gh_response.R
@@ -6,7 +6,7 @@ gh_process_response <- function(resp, gh_req) {
 
   is_raw <- identical(content_type, "application/octet-stream") ||
     isTRUE(grepl("param=raw$", gh_media_type, ignore.case = TRUE))
-  is_ondisk <- inherits(resp$body, "httr2_path")
+  is_ondisk <- inherits(resp$body, "httr2_path") && !is.null(gh_req$dest)
   is_empty <- length(resp$body) == 0
 
   if (is_ondisk) {

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -1,5 +1,7 @@
 test_that("can print all types of object", {
   skip_on_cran()
+  local_options(gh_cache = FALSE)
+
   get_license <- function(...) {
     gh(
       "GET /repos/{owner}/{repo}/contents/{path}",


### PR DESCRIPTION
This is really simple to implement but I think it probably needs some way to suppress and it might cause problems with `R CMD check`. Maybe an option?

Fixes #203