### PR TITLE
Add support for viewer-based credentials on Posit Connect

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,6 +23,7 @@ Imports:
     lifecycle,
     rlang (>= 1.0.0)
 Suggests:
+    connectcreds,
     covr,
     knitr,
     rmarkdown,

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 * `gh()` now uses a cache provided by httr2. This cache lives in `tools::R_user_dir("gh", "cache")`, maxes out at 100 MB, and can be disabled by setting `options(gh_cache = FALSE)` (#203).
 * Removes usage of mockery (@tanho63, #197)
 
+* `gh_token()` can now pick up on the viewer's GitHub credentials (if any) when
+  running on Posit Connect (@atheriel, #217).
+
 # gh 1.4.1
 
 * `gh_next()`, `gh_prev()`, `gh_first()` and `gh_last()`

--- a/tests/testthat/test-gh_token.R
+++ b/tests/testthat/test-gh_token.R
@@ -163,3 +163,11 @@ test_that("get_apiurl() works", {
   expect_equal(get_apiurl("https://github.acme.com/OWNER/REPO"), x)
   expect_equal(get_apiurl("https://github.acme.com/api/v3"), x)
 })
+
+test_that("tokens can be requested from a Connect server", {
+  skip_if_not_installed("connectcreds")
+
+  token <- strrep("a", 40)
+  connectcreds::local_mocked_connect_responses(token = token)
+  expect_equal(gh_token(), gh_pat(token))
+})


### PR DESCRIPTION
This commit brings support for Posit Connect's ["viewer-based credentials" feature][0] to `gh`.

~~Similar to [the recent work in `odbc`][1], the way this is exposed to R users is to require them to pass a Shiny session argument to `gh_token()`, either directly or via `gh()` or `gh_gql()`.~~

Checks for viewer-based credentials are designed to fall back gracefully to existing authentication methods. This is intended to allow users to -- for example -- develop and test a Shiny app that uses GitHub credentials in desktop Positron/RStudio or Posit Workbench and deploy it with no code changes to Connect.

Most of the actual work is outsourced to a new shared package, [`connectcreds`][2].

Unit tests are included.

[0]: https://docs.posit.co/connect/user/oauth-integrations/
[1]: https://github.com/r-dbi/odbc/pull/853
[2]: https://github.com/posit-dev/connectcreds/